### PR TITLE
making field public

### DIFF
--- a/aws_lambda_events/src/sqs/mod.rs
+++ b/aws_lambda_events/src/sqs/mod.rs
@@ -122,7 +122,7 @@ pub struct SqsBatchResponse {
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchItemFailure {
-    item_identifier: String,
+    pub item_identifier: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Making BatchItemFailure.item_identifier public so it can be used