### PR TITLE
SNS: fix missing field SigningCertUrl

### DIFF
--- a/aws_lambda_events/src/generated/fixtures/example-sns-event-obj.json
+++ b/aws_lambda_events/src/generated/fixtures/example-sns-event-obj.json
@@ -13,7 +13,7 @@
         "Timestamp" : "2015-08-18T18:02:32.111Z",
         "SignatureVersion" : "1",
         "Signature" : "e+khMfZriwAOTkF0OVm3tmdVq9eY6s5Bj6rXZty4B2TYssx7SSSBpvsDCiDuzgeHe++MNsGLDDT+5OpGEFBqCcd/K7iXhofz+KabMEtvM2Ku3aXcFixjOCAY1BF8hH6zU6nKzOy+m7K4UIoVqIOOhqsLWoXNFWgwQseBol1pFQ/MRi9UH84/WGdU8//dH+1/zjLxCud8Lg1vY9Yi/jxMU1HVpZ2JuvzJBdNBFJWc/VYAiw8K1r/J+dxAiLr87P96MgUqyg1wWxYe00HaEXGtjIctCNcd92s3pngOOeGvPYGaTIZEbYhSf2leMYd+CXujUHRqozru5K0Zp+l99fUNTg==",
-        "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem",
+        "SigningCertUrl" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem",
         "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:246796806071:snsNetTest:228cc6c9-dcd8-4c92-9f3a-77f55176b9e3"
       }
     }

--- a/aws_lambda_events/src/sns/mod.rs
+++ b/aws_lambda_events/src/sns/mod.rs
@@ -140,7 +140,6 @@ pub struct SnsMessageObj<T: Serialize> {
     pub signature: Option<String>,
 
     /// The URL to the certificate that was used to sign the message.
-    #[serde(rename = "SigningCertURL")]
     pub signing_cert_url: Option<String>,
 
     /// A URL that you can use to unsubscribe the endpoint from this topic. If you visit this URL, Amazon SNS unsubscribes the endpoint and stops sending notifications to this endpoint.


### PR DESCRIPTION
**BUG:**
https://github.com/calavera/aws-lambda-events/issues/129

**FIX:**
remove serde rename "SigningCertURL
